### PR TITLE
WIP: Add fm.testing ns with fdef/check integration

### DIFF
--- a/src/fm/testing.clj
+++ b/src/fm/testing.clj
@@ -1,0 +1,135 @@
+(ns fm.testing
+  (:require [clojure.alpha.spec :as s]
+            [clojure.alpha.spec.test :as stest]
+            [fm.macros :refer [defm]]
+            [fm.utils :refer [fm?]]
+            [clojure.alpha.spec.gen :as gen]))
+
+(s/def ::namespaces
+  (s/coll-of
+   symbol?
+   :kind vector?
+   :distinct true))
+
+(s/def ::check-result any?)
+
+(defn ns->fnsym
+  [ns-sym]
+  (->> ns-sym
+       ns-publics
+       vals
+       (map deref)))
+
+(defm handle-check-failure
+  ^{:fm/args :fm.utils/anomaly}
+  [anomaly]
+  (prn anomaly))
+
+(defn fmdef!
+  ^{:fm/doc "Takes a fn that has fm metadata on it and passes it through to s/fdef."
+    :fm/args :fm/meta
+    :fm/ret symbol?}
+  [{:keys [:fm/sym :fm/args :fm/ret :fm/rel]}]
+  (eval `(s/fdef ~sym
+           :args (or args any?)
+           :ret #(not (s/valid? :fm.utils/anomaly %))
+           :fn (or rel (constantly true)))))
+
+(defm fms-from-ns
+  ^{:fm/args ::namespaces
+    :fm/ret (s/coll-of symbol?)}
+  [namespaces]
+  (->> namespaces
+       (mapcat ns->fnsym)
+       (filter fm?)
+       (map (comp fmdef! meta))))
+
+(defm check
+  ^{:fm/doc "Iterate through namespaces, extracting any fns that have fm metadata, registering those with s/fdef, and finally running them against s/check."
+    :fm/args ::namespaces
+    :fm/ret ::check-result
+    :fm/anomaly handle-check-failure}
+  [namespaces]
+  (->> namespaces
+       (fms-from-ns)
+       (stest/check)))
+
+(comment
+
+  (require '[clojure.alpha.spec.gen :as gen])
+  (gen/sample (gen/gen-for-pred int?))
+
+  (defm test1
+    ^{:fm/args (s/with-gen
+                 (s/cat :n int?)
+                 (fn [] (gen/vec (gen/gen-for-pred int?))))
+      :fm/ret int?}
+    [[n]]
+      (inc n))
+
+  (test1 [2])
+  (fmdef! (meta @#'fm.testing/test1))
+
+  (s/get-spec 'fm.testing/test1)
+
+  (stest/check 'fm.testing/test1)
+
+  (defm test2
+    ^{:fm/args (s/with-gen
+                 (s/cat :n int?)
+                 (fn [] (gen/gen-for-pred int?)))
+      :fm/ret (s/spec int? :gen
+                      (fn [] (gen/gen-for-pred int?)))}
+    [n]
+    (inc n))
+
+  (fmdef! (meta @#'fm.testing/test2))
+
+  (s/get-spec 'fm.testing/test2)
+
+  (stest/check 'fm.testing/test2)
+
+  (defn test3
+    [n]
+    (inc n))
+
+  (s/fdef test3
+    :args
+    (s/with-gen
+      (s/cat :n int?)
+      (fn [] (gen/gen-for-pred int?)))
+    :ret int?)
+
+  (s/get-spec 'fm.testing/test3)
+
+  (stest/check 'fm.testing/test3)
+
+  (defn test4
+    [n]
+    (inc n))
+
+  (s/fdef test4
+    :args int?
+    :ret int?)
+
+  (s/get-spec 'fm.testing/test4)
+
+  (stest/check 'fm.testing/test4)
+
+  (defn test5
+    [n]
+    (inc n))
+
+  (s/fdef test5
+    :args (s/cat :n int?)
+    :ret int?)
+
+  (s/get-spec 'fm.testing/test5)
+
+  (stest/check 'fm.testing/test5)
+
+  (s/def ::number int?)
+  (s/conform (s/spec int?) 5)
+
+  )
+

--- a/src/fm/utils.cljc
+++ b/src/fm/utils.cljc
@@ -3,6 +3,28 @@
    [clojure.alpha.spec.gen :as gen]
    [clojure.alpha.spec :as s]))
 
+(s/def :fm/args
+  (s/or
+   :spec s/spec?
+   :vector (s/coll-of s/spec?)))
+
+(s/def :fm/meta
+  (s/select
+   [:fm/sym :fm/args :fm/ret :fm/rel]
+   [:fm/sym]))
+
+(s/def :fm/ret
+  (s/or
+   :fn fn?
+   :spec s/spec?))
+
+(s/def :fm/rel
+  (s/or
+   :fn fn?
+   :spec s/spec?))
+
+(s/def :fm/sym symbol?)
+
 (defn arg-fmt*
   [arg]
   (cond
@@ -255,10 +277,10 @@
         zipped     (mapv zipv* args-syms args-specs)
         ret-sym    (gensym "ret__")
         ret-spec   (->>
-                    (or (:fm/ret metadata) `any?)
+                    (:fm/ret metadata `any?)
                     (spec-form*))
         anomaly    (->>
-                    (or (:fm/anomaly metadata) `identity)
+                    (:fm/anomaly metadata `identity)
                     (anomaly-form))
         trace      (when-let [trace (:fm/trace metadata)]
                      (->>
@@ -312,6 +334,14 @@
              (anom# #:fm{:sym     '~sym
                          :args    ~args-syms
                          :anomaly (mapv explain* ~zipped)})))))))
+
+(defn fm?
+  "Given a fn symbol, inform if the symbol is wrapped by fm"
+  [fn-meta]
+  (->> fn-meta
+       meta
+       :fm/sym
+       boolean))
 
 (defn genform
   [spec x]

--- a/test/ns1.clj
+++ b/test/ns1.clj
@@ -1,0 +1,48 @@
+(ns fm.test.ns1
+  (:require [fm.macros :refer [fm defm]]
+            [clojure.alpha.spec.gen :as gen]
+            [clojure.alpha.spec :as s]
+            [clojure.alpha.spec.test :as stest]))
+
+(defm defm-test-with-args-and-ret
+  ^{:fm/args (s/cat :n number?)
+    :fm/ret number?}
+  [n]
+  (inc n))
+
+(defm defm-test-with-invalid-ret
+  ^{:fm/args (s/cat :n number?)
+    :fm/ret number?}
+  [n]
+  nil)
+
+(defm defm-test-with-args-and-without-ret
+  ^{:fm/args (s/cat :n number?)}
+  [n]
+  (inc n))
+
+(defm defm-test-without-args-and-ret
+  [n]
+  (inc n))
+
+(defn defn-test-inc
+  [n]
+  (inc n))
+
+(comment
+
+  (meta @#'defm-test-with-args-and-ret)
+  (gen/generate (gen/gen-for-pred int?))
+  (gen/generate (gen/gen-for-pred int?))
+
+  (require '[fm.testing :as t])
+
+  (s/fdef defm-test-with-args-and-ret :args (s/cat :n number?) :ret) 
+  (s/get-spec 'fm.test.ns1/defm-test-with-args-and-ret)
+  #_(:spec :clojure.spec.test.check/ret :sym :failure)
+  (:failure (first (stest/check 'fm.test.ns1/defm-test-with-args-and-ret)))
+  (first (stest/check 'fm.test.ns1/defm-test-with-args-and-ret))
+
+  (keys (s/registry))
+
+  )


### PR DESCRIPTION
The primary interface to `fm.testing` is to use the `check` fn, passing in a list of namespaces that have `fm`-sugared functions. `check` will discover which `defm`'s have appropriate configuration to be passed to `s/fdef`, then passes those symbols on to `stest/check`. The ideal of the interface is that each repo could have a single test file that would look something like this:

```clojure
(ns nuid.ethereum-registration-test
  :require [fm.testing :refer [check]])

(check '[record-registration.stream-handler
               process-registrations.stream-handler
               register.stream-handler])
```

This is a WIP b/c we need to update `fm` to convert `:fm/args` positional specs predicates/specs into `s/cat` catenations (see #7). Also I'll remove the comments (or move them to `nuid.repl`) before we merge of course.