### PR TITLE
Add support for :fm/doc

### DIFF
--- a/src/fm/macros.clj
+++ b/src/fm/macros.clj
@@ -6,15 +6,22 @@
   "The `fm` macro."
   [args-form & body]
   (let [ns-sym (symbol (str *ns* "/" (gensym "fm__")))]
-    (utils/fm-form {:fm/sym       ns-sym
-                    :fm/args-form args-form
-                    :fm/body      body})))
+    (first
+     (utils/fm-form
+      {:fm/sym       ns-sym
+       :fm/args-form args-form
+       :fm/body      body}))))
 
 (defmacro defm
   "The `defm` macro."
   [sym args-form & body]
-  (let [ns-sym (symbol (str *ns* "/" sym))
-        form   (utils/fm-form {:fm/sym       ns-sym
-                               :fm/args-form args-form
-                               :fm/body      body})]
-    `(def ~sym ~form)))
+  (let [ns-sym   (symbol (str *ns* "/" sym))
+        form     (utils/fm-form
+                  {:fm/sym       ns-sym
+                   :fm/args-form args-form
+                   :fm/body      body})
+        metadata (last form)
+        form     (first form)]
+    (if (not (empty? metadata))
+      (list `def (with-meta sym metadata) form)
+      `(def ~sym ~form))))

--- a/src/fm/macros.clj
+++ b/src/fm/macros.clj
@@ -22,6 +22,6 @@
                    :fm/body      body})
         metadata (last form)
         form     (first form)]
-    (if (not (empty? metadata))
+    (if-not (empty? metadata)
       (list `def (with-meta sym metadata) form)
       `(def ~sym ~form))))

--- a/src/fm/usage.cljc
+++ b/src/fm/usage.cljc
@@ -396,6 +396,29 @@
   {:status 200
    :body   (str "echo: " body)})
 
+;; fm supports docstrings
+
+(require '[clojure.repl :as repl])
+
+(defn normal-with-docstring
+  "this is a docstring for a normal defn"
+  [n]
+  (inc n))
+
+(:doc (meta #'normal-with-docstring))
+(repl/doc normal-with-docstring) ; see repl for output
+
+(defm with-docstring
+  ^{:fm/args int?
+    :fm/ret int?
+    :fm/doc "This is a docstring for a defm"}
+  [n]
+  (inc n))
+
+(:fm/doc (meta with-docstring))
+(:doc (meta #'with-docstring))
+(repl/doc with-docstring) ; see repl for output
+
 ;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ;; Now let's test everything out 
 ;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/fm/utils.cljc
+++ b/src/fm/utils.cljc
@@ -333,20 +333,24 @@
   (if (empty? (meta args-form))
     (fn-form form-args)
 
-    (let [metadata    (into {} (map meta-xf) (meta args-form))
-          bindings    (interleave
-                       (map :fm.meta/sym  (vals metadata))
-                       (map :fm.meta/form (vals metadata)))
-          fn-form     (fn-form
-                       (merge
-                        form-args
-                        {:fm/metadata metadata}))
-          symbol-meta (when (:fm/doc metadata)
-                        {:doc (get-in metadata [:fm/doc :fm.meta/form])})
-          meta        (not-empty
-                       (zipmap
-                        (keys metadata)
-                        (map :fm.meta/sym (vals metadata))))]
+    (let [metadata              (into {} (map meta-xf) (meta args-form))
+          metadata-vals         (vals metadata)
+          metadata-key-bindings (map :fm.meta/sym metadata-vals)
+          bindings              (interleave
+                                 metadata-key-bindings
+                                 (map :fm.meta/form metadata-vals))
+          fn-form               (fn-form
+                                 (merge
+                                  form-args
+                                  {:fm/metadata metadata}))
+          symbol-meta           (when (:fm/doc metadata)
+                                  {:doc (get-in
+                                         metadata
+                                         [:fm/doc :fm.meta/form])})
+          meta                  (not-empty
+                                 (zipmap
+                                  (keys metadata)
+                                  metadata-key-bindings))]
 
       [`(let [~@bindings]
           (with-meta ~fn-form ~meta))

--- a/src/fm/utils.cljc
+++ b/src/fm/utils.cljc
@@ -242,6 +242,11 @@
   [k #:fm.meta{:sym  (gensym "trace__")
                :form (trace-form (if (true? v) `prn v))}])
 
+(defmethod meta-xf :fm/doc
+  [[k v]]
+  [k #:fm.meta{:sym  (gensym "doc__")
+               :form v}])
+
 (defmethod meta-xf :default
   [[k v]]
   [k #:fm.meta{:sym  (gensym)

--- a/src/fm/utils.cljc
+++ b/src/fm/utils.cljc
@@ -333,21 +333,24 @@
   (if (empty? (meta args-form))
     (fn-form form-args)
 
-    (let [metadata (into {} (map meta-xf) (meta args-form))
-          bindings (interleave
-                    (map :fm.meta/sym  (vals metadata))
-                    (map :fm.meta/form (vals metadata)))
-          fn-form  (fn-form
-                    (merge
-                     form-args
-                     {:fm/metadata metadata}))
-          meta     (not-empty
-                    (zipmap
-                     (keys metadata)
-                     (map :fm.meta/sym (vals metadata))))]
+    (let [metadata    (into {} (map meta-xf) (meta args-form))
+          bindings    (interleave
+                       (map :fm.meta/sym  (vals metadata))
+                       (map :fm.meta/form (vals metadata)))
+          fn-form     (fn-form
+                       (merge
+                        form-args
+                        {:fm/metadata metadata}))
+          symbol-meta (when (:fm/doc metadata)
+                        {:doc (get-in metadata [:fm/doc :fm.meta/form])})
+          meta        (not-empty
+                       (zipmap
+                        (keys metadata)
+                        (map :fm.meta/sym (vals metadata))))]
 
-      `(let [~@bindings]
-         (with-meta ~fn-form ~meta)))))
+      [`(let [~@bindings]
+          (with-meta ~fn-form ~meta))
+       symbol-meta])))
 
 (defn fm?
   "Given a fn symbol, inform if the symbol is wrapped by fm"


### PR DESCRIPTION
`defn` is a little weird in that it places the docstring into
meta on the symbol that's being def'd, not the value (function).
In order to get similar docs support we have to pass the doc data
back out to the macro (I chose a two-item vector as the result of
fm-form), and then apply that data as meta if present.

Candidly I'm not super happy about the separation of concerns being
violated here (fm metadata producing "outer" meta and having to pass it
back out). Definitely open to another approach. That being said, I could
see us utilzing some of the other outer meta keys like `:argslist`,
`:tag`, etc. ymmv.

If you exercise the newly added examples in usage it should work as
expected. You can get the docstring from the symbol meta as `:doc`,
the fn meta as `:fm/doc`, and also printed to *out* using
`clojure.repl/doc`.

I know you have another few commits to the base branch here, so I'll
rebase them back in and force push here when they land on origin.

Let me know what you think.