### PR TITLE
Add fm/doc

### DIFF
--- a/src/fm/macros.clj
+++ b/src/fm/macros.clj
@@ -9,26 +9,25 @@
                     :fm/args-form args-form
                     :fm/body      body})))
 
-(defmulti  meta-xf (fn [[k _]] k))
-(defmethod meta-xf :fm/doc
+(defmulti  var-meta-xf (fn [[k _]] k))
+(defmethod var-meta-xf :fm/doc
   [[_ v]]
   [:doc v])
 
-(defmethod meta-xf :fm/arglists
+(defmethod var-meta-xf :fm/arglists
   [[_ v]]
   [:arglists `(list '~v)])
 
-(defmethod meta-xf :default
+(defmethod var-meta-xf :default
   [_]
   nil)
 
 (defmacro defm
   [sym args-form & body]
-
   (let [ns-sym   (symbol (str *ns* "/" sym))
         var-meta (into
                   {}
-                  (map meta-xf)
+                  (map var-meta-xf)
                   (merge
                    (meta args-form)
                    {:fm/arglists args-form}))
@@ -36,5 +35,4 @@
         fm-form  (utils/fm-form {:fm/sym       ns-sym
                                  :fm/args-form args-form
                                  :fm/body      body})]
-
     `(def ~fm-sym ~fm-form)))

--- a/src/fm/macros.clj
+++ b/src/fm/macros.clj
@@ -9,10 +9,32 @@
                     :fm/args-form args-form
                     :fm/body      body})))
 
+(defmulti  meta-xf (fn [[k _]] k))
+(defmethod meta-xf :fm/doc
+  [[_ v]]
+  [:doc v])
+
+(defmethod meta-xf :fm/arglists
+  [[_ v]]
+  [:arglists `(list '~v)])
+
+(defmethod meta-xf :default
+  [_]
+  nil)
+
 (defmacro defm
   [sym args-form & body]
-  (let [ns-sym (symbol (str *ns* "/" sym))
-        form   (utils/fm-form {:fm/sym       ns-sym
-                               :fm/args-form args-form
-                               :fm/body      body})]
-    `(def ~sym ~form)))
+
+  (let [ns-sym   (symbol (str *ns* "/" sym))
+        var-meta (into
+                  {}
+                  (map meta-xf)
+                  (merge
+                   (meta args-form)
+                   {:fm/arglists args-form}))
+        fm-sym   (with-meta sym var-meta)
+        fm-form  (utils/fm-form {:fm/sym       ns-sym
+                                 :fm/args-form args-form
+                                 :fm/body      body})]
+
+    `(def ~fm-sym ~fm-form)))

--- a/src/fm/test/usage.cljc
+++ b/src/fm/test/usage.cljc
@@ -5,23 +5,23 @@
    [fm.test.check :as fm.check]
    [fm.test.report :as fm.report]))
 
-;; This should pass
 (defm add1
-  ^{:fm/args int?
+  ^{:fm/doc  "Should pass `fm.check/check!`"
+    :fm/args int?
     :fm/ret  int?}
   [n]
   (inc n))
 
-;; This should fail
 (defm add5
-  ^{:fm/args nil? ;; let's cause an exception to be thrown by check
+  ^{:fm/doc  "Should fail `fm.check/check!` with `:fm.anomaly/throw`"
+    :fm/args nil?
     :fm/ret  int?}
   [n]
   (+ n 5))
 
-;; This should also fail
 (defm expected-spec-failure
-  ^{:fm/args any? ;; let's cause an exception to be thrown by check
+  ^{:fm/doc  "Should fail `fm.check/check!` with `:fm.anomaly/ret`"
+    :fm/args any?
     :fm/ret  int?}
   [x]
   x)

--- a/src/fm/test/usage.cljc
+++ b/src/fm/test/usage.cljc
@@ -43,7 +43,7 @@
 (get-in check-result-data [:total :fns])             ; how many fns did we test?
 (get-in check-result-data [:total :num-tests])       ; how many tests were generated?
 (get-in check-result-data [:total :passed])          ; how many passed?
-(get-in check-result-data [:total :failed])          ; how many failed
+(get-in check-result-data [:total :failed])          ; how many failed?
 (get-in check-result-data [:total :time-elapsed-ms]) ; how long did it take?
 
   ;; print report to *out*

--- a/src/fm/usage.cljc
+++ b/src/fm/usage.cljc
@@ -13,6 +13,9 @@
 (inc_ 1)
 (inc_ 'a)
 
+(meta inc_)
+(meta #'inc_)
+
   ;; fm is just fn
 (macroexpand '(defm inc_
                 [n]
@@ -24,6 +27,9 @@
 
 (inc_ 1)
 (inc_ 'a) ; this is anomaly 3: `:fm.anomaly/throw`
+
+(meta inc_)
+(meta #'inc_)
 
 (defm inc_
   ^{:fm/args number?}
@@ -79,6 +85,15 @@
   ;; anonymous fm
 ((fm ^{:fm/args number?} [n] (inc n)) 1)
 ((fm ^{:fm/args number?} [n] (inc n)) 'a)
+
+  ;; doc
+(defm doct
+  ^{:fm/doc "Is documented."}
+  [n]
+  (inc n))
+
+(meta doct)
+(meta #'doct)
 
   ;; variadic signatures aren't ready yet, but otherwise...
 (defm add_

--- a/src/fm/usage.cljc
+++ b/src/fm/usage.cljc
@@ -115,7 +115,7 @@
 (defm custom-anomaly
   ^{:fm/handler "dang!"}
   []
-  (throw (Exception. "darn!")))
+  (throw (ex-info "darn!" {})))
 
 (custom-anomaly)
 
@@ -127,14 +127,14 @@
 (defm custom-anomaly2
   ^{:fm/handler log!}
   []
-  (throw (Exception. "darn!")))
+  (throw (ex-info "darn!" {})))
 
 (custom-anomaly2)
 
 (defm custom-anomaly3
   ^{:fm/handler (fn [anomaly] (prn anomaly))}
   []
-  (throw (Exception. "darn!")))
+  (throw (ex-info "darn!" {})))
 
 (custom-anomaly3)
 

--- a/src/fm/utils.cljc
+++ b/src/fm/utils.cljc
@@ -318,13 +318,13 @@
                   (merge
                    form-args
                    {:fm/metadata metadata}))
-        meta     (not-empty
+        fn-meta  (not-empty
                   (zipmap
                    (keys metadata)
                    (map :fm.meta/sym (vals metadata))))]
 
     `(let [~@bindings]
-       (with-meta ~fn-form ~meta))))
+       (with-meta ~fn-form ~fn-meta))))
 
 (defn fm?
   [sym]

--- a/src/fm/utils.cljc
+++ b/src/fm/utils.cljc
@@ -199,33 +199,33 @@
   [x]
   (not (anomaly? x)))
 
-(defmulti  meta-xf (fn [[k _]] k))
-(defmethod meta-xf :fm/sym
+(defmulti  fn-meta-xf (fn [[k _]] k))
+(defmethod fn-meta-xf :fm/sym
   [[k v]]
   [k #:fm.meta{:sym  (gensym "sym__")
                :form `'~v}])
 
-(defmethod meta-xf :fm/args
+(defmethod fn-meta-xf :fm/args
   [[k v]]
   [k #:fm.meta{:sym  (gensym "args-spec__")
                :form (args-spec-form* (if (vector? v) v [v]))}])
 
-(defmethod meta-xf :fm/ret
+(defmethod fn-meta-xf :fm/ret
   [[k v]]
   [k #:fm.meta{:sym  (gensym "ret-spec__")
                :form (ret-spec-form v)}])
 
-(defmethod meta-xf :fm/handler
+(defmethod fn-meta-xf :fm/handler
   [[k v]]
   [k #:fm.meta{:sym  (gensym "handler__")
                :form (handler-form v)}])
 
-(defmethod meta-xf :fm/trace
+(defmethod fn-meta-xf :fm/trace
   [[k v]]
   [k #:fm.meta{:sym  (gensym "trace__")
                :form (trace-form (if (true? v) `prn v))}])
 
-(defmethod meta-xf :default
+(defmethod fn-meta-xf :default
   [[k v]]
   [k #:fm.meta{:sym  (gensym)
                :form v}])
@@ -310,7 +310,7 @@
 
   (let [metadata (->>
                   (merge (meta args-form) {:fm/sym sym})
-                  (into {} (map meta-xf)))
+                  (into {} (map fn-meta-xf)))
         bindings (interleave
                   (map :fm.meta/sym  (vals metadata))
                   (map :fm.meta/form (vals metadata)))


### PR DESCRIPTION
Addresses #5 by adding `var-meta-xf`, which formats the fm metadata to emulate `defn`.