### PR TITLE
Fix cljs support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 
 # nREPL
 .nrepl-port
+
+# cljs
+.cljs_node_repl
+out

--- a/deps.edn
+++ b/deps.edn
@@ -1,2 +1,3 @@
-{:deps  {org.clojure/clojure {:mvn/version "1.10.0"}}
- :paths ["src"]}
+{:deps    {org.clojure/clojure {:mvn/version "1.10.0"}}
+ :aliases {:cljs {:extra-deps {org.clojure/clojurescript {:mvn/version "1.10.758"}}}}
+ :paths   ["src"]}

--- a/src/fm/cljs.cljs
+++ b/src/fm/cljs.cljs
@@ -1,0 +1,62 @@
+(ns fm.cljs
+  (:require
+   [clojure.core.specs.alpha :as core.specs]
+   [clojure.spec.alpha :as s]))
+
+
+   ;;;
+   ;;; NOTE: `fm` depends on the ability to conform against these specs from
+   ;;; `clojure.core`. in clojure, these specs are in the registry by default.
+   ;;; in clojurescript, these specs are not included when the registry is
+   ;;; redefined for spec consumers. the following is a stopgap until a better
+   ;;; way to inherit these specs in clojurescript is identified
+   ;;;
+
+
+;   Copyright (c) Rich Hickey. All rights reserved.
+;   The use and distribution terms for this software are covered by the
+;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;   which can be found in the file epl-v10.html at the root of this distribution.
+;   By using this software in any fashion, you are agreeing to be bound by
+;   the terms of this license.
+;   You must not remove this notice, or any other, from this software.
+
+(s/def ::core.specs/local-name (s/and simple-symbol? #(not= '& %)))
+
+(s/def ::core.specs/binding-form
+  (s/or :local-symbol ::core.specs/local-name
+        :seq-destructure ::core.specs/seq-binding-form
+        :map-destructure ::core.specs/map-binding-form))
+
+(s/def ::core.specs/seq-binding-form
+  (s/and vector?
+         (s/cat :forms (s/* ::core.specs/binding-form)
+                :rest-forms (s/? (s/cat :ampersand #{'&} :form ::core.specs/binding-form))
+                :as-form (s/? (s/cat :as #{:as} :as-sym ::core.specs/local-name)))))
+
+(s/def ::core.specs/keys (s/coll-of ident? :kind vector?))
+(s/def ::core.specs/syms (s/coll-of symbol? :kind vector?))
+(s/def ::core.specs/strs (s/coll-of simple-symbol? :kind vector?))
+(s/def ::core.specs/or (s/map-of simple-symbol? any?))
+(s/def ::core.specs/as ::core.specs/local-name)
+
+(s/def ::core.specs/map-special-binding
+  (s/keys :opt-un [::core.specs/as ::core.specs/or ::core.specs/keys
+                   ::core.specs/syms ::core.specs/strs]))
+
+(s/def ::core.specs/map-binding (s/tuple ::core.specs/binding-form any?))
+
+(s/def ::core.specs/ns-keys
+  (s/tuple
+    (s/and qualified-keyword? #(-> % name #{"keys" "syms"}))
+    (s/coll-of simple-symbol? :kind vector?)))
+
+(s/def ::core.specs/map-bindings
+  (s/every (s/or :map-binding ::core.specs/map-binding
+                 :qualified-keys-or-syms ::core.specs/ns-keys
+                 :special-binding (s/tuple #{:as :or :keys :syms :strs} any?)) :kind map?))
+
+(s/def ::core.specs/map-binding-form
+  (s/merge
+   ::core.specs/map-bindings
+   ::core.specs/map-special-binding))

--- a/src/fm/form.cljc
+++ b/src/fm/form.cljc
@@ -161,88 +161,10 @@
    ;;;
 
 
-(def fn-symbol?
-  (comp lib/fn? deref resolve))
-
-(s/def ::bound-fn
-  (s/and
-   symbol?
-   resolve
-   fn-symbol?)) ; NOTE: `requiring-resolve`?
-
-(def bound-fn?
-  (partial s/valid? ::bound-fn))
-
-(def first-bound-fn?
-  (comp bound-fn? first))
-
-(s/def ::fn-form
-  (s/and
-   seq?
-   not-empty
-   first-bound-fn?))
-
-(def fn-form?
-  (partial s/valid? ::fn-form))
-
-(def first-symbol?
-  (comp symbol? first))
-
-(def first-resolves?
-  (comp resolve first)) ; ALT: boolean
-
-(def first-spec-namespace?
-  (comp
-   (hash-set
-    (namespace `s/*))
-   namespace
-   symbol
-   resolve
-   first)) ; TODO: revisit
-
-(s/def ::spec-form
-  (s/and
-   seq?
-   not-empty
-   first-symbol?
-   first-resolves?
-   first-spec-namespace?))
-
-(def spec-form?
-  (partial s/valid? ::spec-form))
-
-(def spec-form-hierarchy-atom
-  (atom
-   (->
-    (make-hierarchy)
-    (derive `s/cat ::s/regex-op)
-    (derive `s/alt ::s/regex-op)
-    (derive `s/* ::s/regex-op)
-    (derive `s/+ ::s/regex-op)
-    (derive `s/? ::s/regex-op)
-    (derive `s/& ::s/regex-op))))
-
-  ;; NOTE: `comp` evaluates set, breaks rebinding
-(defn first-regex-op-symbol?
-  [spec-form]
-  (isa? @spec-form-hierarchy-atom
-        (first spec-form)
-        ::s/regex-op))
-
-(s/def ::regex-op-form
-  (s/and
-   ::spec-form
-   first-regex-op-symbol?))
-
-(def regex-op-form?
-  (partial s/valid? ::regex-op-form))
-
-  ;; TODO: test-only generators
-  ;; NOTE: `s/get-spec` contributes to disambiguation
 (s/def ::s/registry-keyword
   (s/and
    qualified-keyword?
-   s/get-spec))
+   s/get-spec)) ; NOTE: `s/get-spec` contributes to disambiguation
 
 (s/def ::positional-binding-map
   (s/map-of
@@ -331,6 +253,7 @@
   ;; TODO: `:fm/ignore`, runtime `*ignore*`, `s/*compile-asserts*`, etc.
   ;; TODO: `:fm/memoize`
   ;; TODO: global spec form deduplication; `registry`, `bind!`
+  ;; TODO: test generators
   ;; ALT: reader literals; (vector ,,,) vs. [,,,], `into`
   ;; ALT: qualify positional tags e.g. (s/cat :fm.signature/0 ,,,)
   ;; ALT: `core.match`; [tag x]

--- a/src/fm/form.cljc
+++ b/src/fm/form.cljc
@@ -2,7 +2,8 @@
   (:require
    [clojure.core.specs.alpha :as core.specs]
    [clojure.spec.alpha :as s]
-   [fm.lib :as lib]))
+   [fm.lib :as lib]
+   #?@(:cljs [[fm.cljs]])))
 
 
    ;;;
@@ -162,9 +163,7 @@
 
 
 (s/def ::s/registry-keyword
-  (s/and
-   qualified-keyword?
-   s/get-spec)) ; NOTE: `s/get-spec` contributes to disambiguation
+   qualified-keyword?)
 
 (s/def ::positional-binding-map
   (s/map-of

--- a/src/fm/form/fn.cljc
+++ b/src/fm/form/fn.cljc
@@ -37,8 +37,8 @@
 
 
 (s/def ::metadata-fn-form
-  (s/or ::form/bound-fn ::form/bound-fn
-        ::form/fn-form ::form/fn-form)) ; ALT: `fm../sum` spec-op; `s/or-of` spec2 wiki example
+  (s/or :list list?
+        :symbol symbol?))
 
 (s/def ::metadata-specv-form
   (s/or :fm.context/nominal (s/tuple vector?)
@@ -46,7 +46,6 @@
 
 (s/def ::metadata-spec-form
   (s/or ::s/registry-keyword ::s/registry-keyword
-        ::form/spec-form ::form/spec-form
         ::metadata-fn-form ::metadata-fn-form
         ::metadata-specv-form ::metadata-specv-form))
 
@@ -846,7 +845,7 @@
         (when-let [form (or (get-in ctx [::metadata :fm/trace index])
                             (get-in ctx [::defaults :fm/trace]))]
           (let [pred? (some-fn true? set?)
-                fn?   (some-fn form/fn-form? form/bound-fn?)]
+                fn?   (some-fn list? symbol?)]
             (cond
               (pred? form)  (get-in ctx [::defaults :fm/trace-fn])
               (fn? form)    form
@@ -859,7 +858,7 @@
   (let [index (signature-index ctx)]
     (or (get-in ctx [::form/bindings :fm/handler index ::form/symbol])
         (let [form (get-in ctx [::metadata :fm/handler index])
-              fn?  (some-fn form/fn-form? form/bound-fn?)]
+              fn?  (some-fn list? symbol?)]
           (cond
             (fn? form) form
             :else      (get-in ctx [::defaults :fm/handler])))))) ; TODO: nil handler case
@@ -1340,8 +1339,7 @@
       (form/->form ctx (conj tag t)))))
 
 (defmethod form/->form [::s/form :fm/spec ::s/registry-keyword] [k _] k)
-(defmethod form/->form [::s/form :fm/spec ::form/spec-form] [form _] form)
-(defmethod form/->form [::s/form :fm/spec ::metadata-fn-form] [f _] f) ; NOTE: may require `s/spec` in spec2
+(defmethod form/->form [::s/form :fm/spec ::metadata-fn-form] [form _] form) ; NOTE: may require `s/spec` in spec2
 (defmethod form/->form [::s/form :fm/spec ::metadata-specv-form]
   [ctx [_ spec-tag _ :as tag]]
   (let [specv       (get ctx spec-tag)

--- a/src/fm/form/fn.cljc
+++ b/src/fm/form/fn.cljc
@@ -236,7 +236,7 @@
 (defn conformed-definition [ctx]
   (try
     (lib/conform-throw! ::definition (get ctx ::definition))
-    (catch Throwable t
+    (catch #?(:clj Throwable :cljs :default) t
       (let [msg  (str "Are all positional spec params in the registry?\n\n"
                       (ex-message t))
             data (merge ctx (ex-data t))]

--- a/src/fm/lib.cljc
+++ b/src/fm/lib.cljc
@@ -10,10 +10,15 @@
 
 
 (def multifn?
-  (partial instance? clojure.lang.MultiFn))
+  (partial
+   instance?
+   #?(:clj clojure.lang.MultiFn
+      :cljs cljs.core/MultiFn)))
 
 (def fn?
-  (some-fn clojure.core/fn? multifn?))
+  (some-fn
+   clojure.core/fn?
+   multifn?))
 
 (def singular? ; ALT: `singleton?`
   (every-pred


### PR DESCRIPTION
resolves #26

the cljs-incompatible predicates (i.e. those that used `resolve` as a function) were smells in any case, so it's a welcome change to factor those out entirely and accept the relaxed definition validation.

fixing support also required relaxing `::s/registry-keyword`, due to differences in how `s/get-spec` works across hosts. this came as a surprise, and i still don't fully understand the cljs limitation. this hints at revisiting the binding map definition, but that can be addressed as needed in a follow up.