### PR TITLE
Add conform-tag

### DIFF
--- a/src/fm/core.cljc
+++ b/src/fm/core.cljc
@@ -24,6 +24,7 @@
 
 (def conform-explain lib/conform-explain)
 (def conform-throw! lib/conform-throw!)
+(def conform-tag lib/conform-tag)
 
 
    ;;;

--- a/src/fm/lib.cljc
+++ b/src/fm/lib.cljc
@@ -49,6 +49,13 @@
         (s/explain-data spec x)))
       c)))
 
+(defn conform-tag
+  [spec x]
+  (let [c (s/conform spec x)]
+    (if (s/invalid? c)
+      (vector c x)
+      c)))
+
 
    ;;;
    ;;; NOTE: data transformations


### PR DESCRIPTION
tiny utility for normalizing the common case of wanting to compute over the result of conformance against a tagging spec (`s/or`, `s/alt`, etc.), e.g.

```clojure
(s/def ::or1
  (s/or
   :a even?
   :b odd?
   :c symbol?))
    
(defn f1 [x]
  (let [tagged (fm/conform-tag ::or1 x)]
    (case (first tagged)
      :a          (inc x)
      :b          (dec x)
      :c          (str x)
      ::s/invalid 'handle-error))))
```

`fm/conform-throw!` can be useful in similar cases where you'd rather fail fast upon encountering invalid data. `fm/conform-tag` is convenient in cases where you want to handle the error inline.